### PR TITLE
refactor:: otimizando consulta de conflitos de intervalo e removendo cache 

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -38,7 +38,6 @@ $routes->group('sys', function ($routes)
         $routes->get('dadosDaAula/(:num)', 'TabelaHorarios::dadosDaAula/$1');
         $routes->post('fixarAula', 'TabelaHorarios::fixarAula');
         $routes->get('verificar-todos-conflitos', 'AulaHorarioController::verificarConflitosRotina');
-
         $routes->post('bypassAula', 'TabelaHorarios::bypassAula');
     });
 

--- a/app/Controllers/AulaHorarioController.php
+++ b/app/Controllers/AulaHorarioController.php
@@ -13,16 +13,19 @@ class AulaHorarioController extends BaseController
     $versaoId = (new \App\Models\VersoesModel())->getVersaoByUser(auth()->id());
 
     $model = new \App\Models\AulaHorarioModel();
+    
     $amb  = $model->countConflitosAmbiente($versaoId);
     $prof = $model->countConflitosProfessor($versaoId);
     $restricao = $model->countRestricaoDocente($versaoId);
     $turnos = $model->countTresTurnos($versaoId);
+    $intervalo = $model->countTempoEntreTurnos($versaoId);
 
     $conflitos = [
       'CONFLITO-AMBIENTE' => $amb,
       'CONFLITO-PROFESSOR' => $prof,
       'RESTRIÇÃO-DOCENTE' => $restricao,
       'CONFLITO-TURNOS' => $turnos,
+      'CONFLITO-INTERVALO' => $intervalo,
     ];
 
     return $this->response->setJSON($conflitos);

--- a/app/Controllers/AulaHorarioController.php
+++ b/app/Controllers/AulaHorarioController.php
@@ -4,28 +4,13 @@ namespace App\Controllers;
 
 use App\Controllers\BaseController;
 
-use App\Models\CursosModel;
-use App\Models\VersoesModel;
-use App\Models\AmbientesModel;
 use App\Models\AulaHorarioModel;
-use App\Models\AulaHorarioAmbienteModel;
-use CodeIgniter\HTTP\Request;
-use CodeIgniter\HTTP\ResponseInterface;
-use CodeIgniter\Cache\CacheInterface;
-
 
 class AulaHorarioController extends BaseController
 {
   public function verificarConflitosRotina() {
 
-    $cache = cache(); /** @var CacheInterface $cache */
-
     $versaoId = (new \App\Models\VersoesModel())->getVersaoByUser(auth()->id());
-
-    $cacheKey = "rotina_conflitos{$versaoId}";
-    if ($conflitos = $cache->get($cacheKey)) {
-        return $this->response->setJSON($conflitos);
-    }
 
     $model = new \App\Models\AulaHorarioModel();
     $amb  = $model->countConflitosAmbiente($versaoId);
@@ -39,8 +24,6 @@ class AulaHorarioController extends BaseController
       'RESTRIÇÃO-DOCENTE' => $restricao,
       'CONFLITO-TURNOS' => $turnos,
     ];
-
-    $cache->save($cacheKey, $conflitos, 60);
 
     return $this->response->setJSON($conflitos);
   }

--- a/app/Views/sys/home.php
+++ b/app/Views/sys/home.php
@@ -281,6 +281,12 @@ document.addEventListener("DOMContentLoaded", function () {
           icone: 'mdi-account-cancel-outline',
           texto: 'Restrição de Professor'
         },
+
+        'CONFLITO-INTERVALO': {
+          cor: 'danger',
+          icone: 'mdi-timer-off-outline',
+          texto: 'Conflitos de Intervalo'
+        },
         
       };
 


### PR DESCRIPTION
### Descrição
A dashboard deve ter um tempo de carregamento aceitável. Removi o cache de 60 segundos.

### Critérios de Aceitação
- [ ] Mostrar os 5 tipos de conflitos na dashboard, caso haja (conflito de intervalos incluso).
- [ ] Carregamento da página eficiente e em tempo hábil. 

### Testes
- [ ] Abrir em produção e verificar se está realmente otimizado mesmo após a remoção do cache.