### PR TITLE
feat: impedir disciplinas repetidas

### DIFF
--- a/app/Controllers/Aulas.php
+++ b/app/Controllers/Aulas.php
@@ -12,7 +12,6 @@ use App\Models\DisciplinasModel;
 use App\Models\ProfessorModel;
 use App\Models\MatrizCurricularModel;
 use App\Models\VersoesModel;
-use App\Models\AulaHorarioModel;
 use CodeIgniter\Exceptions\ReferenciaException;
 
 class Aulas extends BaseController
@@ -51,14 +50,21 @@ class Aulas extends BaseController
 		foreach ($dadosPost['turmas'] as $k => $v) {
 
 			$aulaExistente = $aula
+		->select('turmas.sigla AS sigla_turma, disciplinas.nome AS nome_disciplina')
+		->join('turmas', 'turmas.id = aulas.turma_id')
+		->join('disciplinas', 'disciplinas.id = aulas.disciplina_id')
 		->where('disciplina_id', $dadosPost['disciplina'])
 		->where('versao_id', $versaoId)
 		->where('turma_id', $v)
 		->first();
 
 		if($aulaExistente) {
-				$mensagem = "<b>Não é possível cadastrar uma aula com disciplina repetida!</b>";
-				return $mensagem;
+
+				return $this->response->setJSON([
+        'message' => 'Não é possível cadastrar uma aula com disciplina repetida!</br>'
+								.'Turma: '.$aulaExistente['sigla_turma'].'</br>'
+								.'Disciplina: '.$aulaExistente['nome_disciplina']
+    ]);
 		}
 
 			$insert = [
@@ -135,7 +141,7 @@ class Aulas extends BaseController
 				if ($restricoes['horarios']) {
 					$mensagem = $mensagem . "<br><b>Horário(s) relacionado(s) a ela:</b><br><ul>";
 					foreach($restricoes['horarios'] as $h) {
-						$mensagem = $mensagem . "<li><b>Dia/Horário:</b> $h->dia_semana | $h->intervalo</li>";
+						$mensagem = $mensagem . "<li><b>Dia/Horárioooooo:</b> $h->dia_semana | $h->intervalo</li>";
 					}
 					$mensagem = $mensagem . "</ul>";
 				}

--- a/app/Controllers/Aulas.php
+++ b/app/Controllers/Aulas.php
@@ -46,8 +46,21 @@ class Aulas extends BaseController
 		$aula = new AulasModel();
 		$aula_prof = new AulaProfessorModel();
 		$versaoModel = new VersoesModel();
+		$versaoId = (new \App\Models\VersoesModel())->getVersaoByUser(auth()->id());
 
 		foreach ($dadosPost['turmas'] as $k => $v) {
+
+			$aulaExistente = $aula
+		->where('disciplina_id', $dadosPost['disciplina'])
+		->where('versao_id', $versaoId)
+		->where('turma_id', $v)
+		->first();
+
+		if($aulaExistente) {
+				$mensagem = "<b>Não é possível cadastrar uma aula com disciplina repetida!</b>";
+				return $mensagem;
+		}
+
 			$insert = [
 				"disciplina_id" => $dadosPost['disciplina'],
 				"turma_id" => $v,

--- a/app/Views/components/aulas/modal-cad-aula.php
+++ b/app/Views/components/aulas/modal-cad-aula.php
@@ -214,7 +214,7 @@
                         // Recarregar a tabela de aulas
                         table.ajax.reload();
                     } else {
-                        alert("Erro ao cadastrar a aula: " + response);
+                        $.toast({ heading:'erro', text:response.message, icon:'error' });
                     }
                 },
                 error: function() {


### PR DESCRIPTION
#31 

### Descrição
Como usuário, ao tentar cadastrar uma aula com disciplinas já existentes nas mesma turma, devo receber uma mensagem de erro indicando que não é possível cadastrar aulas repetidas.

### Critérios de Aceitação
- [ ] O cadastro de aula deve validar se a aula que está sendo cadastrada já existe.
- [ ] A verificação de aula repetida ocorre por turma e disciplina.
- [ ] Ao detectar aula existente, mostra a notificação com o tooltip de erro indicando turma e disciplina que está conflitando(para o caso do usuário estar tentando cadastrar várias). 

### Testes
- [ ] Abrir em aulas e cadastrar uma aula.
- [ ] Tentar cadastrar a mesma aula novamente, com todos os dados iguais.
- [ ] Verificar se a notificação de erro aparece e se contém as informações necessárias.